### PR TITLE
fix: updated references to GitHub repository

### DIFF
--- a/ocp-deploy.sh
+++ b/ocp-deploy.sh
@@ -4,7 +4,7 @@ oc project naps-emergency-response
 
 oc new-app \
 --image-stream=nodejs \
---code=https://github.com/NAPS-emergency-response-project/emergency-console \
+--code=https://github.com/Emergency-Response-Demo/emergency-console \
 --name=emergency-console
 
 oc create route edge --service=emergency-console --cert=server.cert --key=server.key

--- a/src/app/sidebar/sidebar.component.html
+++ b/src/app/sidebar/sidebar.component.html
@@ -12,7 +12,7 @@
         routerLinkActive="nav-link-primary"> <i class="nav-icon cui-location-pin"></i> Incidents </a>
       </li>
       <li class="nav-item">
-        <a class="nav-link" href="https://github.com/NAPS-emergency-response-project" target="_blank">
+        <a class="nav-link" href="https://github.com/Emergency-Response-Demo" target="_blank">
           <fa-icon [icon]="githubIcon" class="nav-icon"></fa-icon> Github
         </a>
       </li>


### PR DESCRIPTION
GitHub links were pointing to https://github.com/NAPS-emergency-response-project - an organisation that does not exist.