### PR TITLE
Ensure status is treated as REPORTED if undefined for incidents

### DIFF
--- a/src/app/dashboard/dashboard.component.ts
+++ b/src/app/dashboard/dashboard.component.ts
@@ -117,7 +117,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
 
   private handleIncidentUpdate(incident: Incident): void {
     const currentIncident = this.incidentMap[incident.id];
-    this.incidentMap[incident.id] = Object.assign({}, currentIncident, incident);
+    this.incidentMap[incident.id] = Object.assign({ status: 'REPORTED' }, currentIncident, incident);
   }
 
   private handleResponderUpdate(responder: Responder): void {

--- a/src/app/incident/incident.component.ts
+++ b/src/app/incident/incident.component.ts
@@ -4,8 +4,7 @@ import { IncidentStatus } from '../models/incident-status';
 @Component({
   selector: 'app-incident',
   templateUrl: './incident.component.html',
-  styleUrls: ['./incident.component.css'],
-  changeDetection: ChangeDetectionStrategy.OnPush
+  styleUrls: ['./incident.component.css']
 })
 export class IncidentComponent implements OnInit {
 


### PR DESCRIPTION
The UI responds to incidents based on their statuses. If a status is undefined it should be treated as REPORTED.