### PR TITLE
fix permission issue with the env.js file and bump version

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+e2e
+node_modules
+tmp
+dist
+Dockerfile
+.git
+.gitignore
+.circleci
+npm-debug.log
+README.md
+docs
+ocp-*.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,8 @@ COPY . ./
 RUN npm install
 RUN npm run-script build
 
+RUN chmod 777 dist/assets/js/env.js
+
 EXPOSE 8080
 
 ENTRYPOINT [ "npm", "run", "start" ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "emergency-console",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "emergency-console",
   "author": "Mike Echevarria <mechevar@redhat.com>",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
I am getting an error on server startup complaining cannot modify `dist/assets/js/env.js` file when deployed to openshift. This change will make sure the file has the right permission to allow modification.