### PR TITLE
Use disaster simulator route from emergency console, not the service

### DIFF
--- a/server.js
+++ b/server.js
@@ -26,6 +26,7 @@ app.set('incident-priority-service', process.env.PRIORITY || 'http://incident-pr
 app.set('process-viewer', process.env.PROCESS_VIEWER || 'http://process-viewer:8080');
 app.set('responder-simulator', process.env.RESPONDER_SIMULATOR || 'http://responder-simulator:8080');
 app.set('disaster-simulator', process.env.DISASTER_SIMULATOR || 'http://disaster-simulator:8080');
+app.set('disaster-simulator-route', process.env.DISASTER_SIMULATOR_ROUTE || 'http://disaster-simulator:8080');
 app.set('kafka-host', process.env.KAFKA_HOST || 'kafka-cluster-kafka-bootstrap.naps-emergency-response.svc:9092');
 app.set('kafka-message-topic', ['topic-mission-event', 'topic-responder-location-update', 'topic-incident-event', 'topic-responder-event', 'topic-incident-command', 'topic-responder-command']);
 if (process.env.KAFKA_TOPIC) {
@@ -185,7 +186,7 @@ app.use(
 
 app.use(
   '/disaster-simulator$', function(req, res) {
-    res.redirect(app.get("disaster-simulator"));
+    res.redirect(app.get("disaster-simulator-route"));
   }
 );
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/5431427/106309979-dbc4eb80-6230-11eb-98f1-3b478c123ae1.png)
The link to the disaster simulator shown above is currently using the service, not the route, giving  a 404 in the user's browser. This should fix that, since our emergency-console DeploymentConfig already has the environment variable.